### PR TITLE
Fix display of result background...

### DIFF
--- a/site/public/css/app.css
+++ b/site/public/css/app.css
@@ -273,6 +273,7 @@ div.result {
     color: #2290c6;
     background: url(../img/grad1.png);
     background-repeat: repeat-x;
+    background-position: 100% 100%;
     border: 1px solid #b2b2b2;
     -moz-border-radius: 10px;
     border-radius: 10px;


### PR DESCRIPTION
CSS change so background gradient fills result box for results with long
descriptions. Fixes part B of #16 (part A seemingly already fixed)